### PR TITLE
Remove \ignorespaces that was causing 'Abstract' to be glued with the…

### DIFF
--- a/imsart.sty
+++ b/imsart.sty
@@ -1776,7 +1776,7 @@
         \abstract@size
         \parindent=\sv@parindent
         \noindent\hskip\abstract@indent
-        {\abstractname@size\abstractname\abstractname@skip}\ignorespaces
+        {\abstractname@size\abstractname\abstractname@skip}
     }
 %
 \def\endabstract{\par\egroup}


### PR DESCRIPTION
… user-written abstract.

	- Reproduce:
	- Add package \usepackage[english]{babel}
	- Write something on the abstract
	- Compile
	- Observe that the text "Abstract" is glued, with no spacing,
	to the abstract you wrote.